### PR TITLE
插件中activity可能会无限重启的问题

### DIFF
--- a/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/hook/handle/PluginInstrumentation.java
+++ b/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/hook/handle/PluginInstrumentation.java
@@ -164,7 +164,10 @@ public class PluginInstrumentation extends Instrumentation {
                 ActivityInfo stubInfo = targetIntent.getParcelableExtra(Env.EXTRA_STUB_INFO);
                 if (targetInfo != null && stubInfo != null) {
                     RunningActivities.onActivtyCreate(activity, targetInfo, stubInfo);
-                    activity.setRequestedOrientation(targetInfo.screenOrientation);
+                    if (activity.getRequestedOrientation() == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+                            && targetInfo.screenOrientation != ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) {
+                        activity.setRequestedOrientation(targetInfo.screenOrientation);
+                    }
                     PluginManager.getInstance().onActivityCreated(stubInfo, targetInfo);
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                         fixTaskDescription(activity, targetInfo);


### PR DESCRIPTION
插件中无论横竖屏是在minifest 中设置还是代码设置都是在 PluginInstrumentation中通过activity.setRequestedOrientation(targetInfo.screenOrientation)动态设置的, 所以在插件中如果启动一个activity , 并且这个activity onCreate 中也通过setRequestedOrientation(targetInfo.screenOrientation) 设置横竖屏, 可能会导致activity 无限重启, 这个提交判断使onCreate 最多只调用2次, 还有一个方式只让activity 重启一次 就是在DP 预注册的所有activity 中加上android:configChanges="orientation|keyboardHidden|screenSize"字段, 不过觉得改变所有activity 注册行为不太妥当, 所以这部分没有提交