### PR TITLE
manifest中定义的独立进程的services会被误认为是插件

### DIFF
--- a/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/core/PluginProcessManager.java
+++ b/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/core/PluginProcessManager.java
@@ -111,7 +111,7 @@ public class PluginProcessManager {
             sProcessList.add(context.getPackageName());
 
             PackageManager pm = context.getPackageManager();
-            PackageInfo packageInfo = pm.getPackageInfo(context.getPackageName(), PackageManager.GET_RECEIVERS | PackageManager.GET_ACTIVITIES | PackageManager.GET_PROVIDERS);
+            PackageInfo packageInfo = pm.getPackageInfo(context.getPackageName(), PackageManager.GET_RECEIVERS | PackageManager.GET_ACTIVITIES | PackageManager.GET_PROVIDERS | PackageManager.GET_SERVICES);
             if (packageInfo.receivers != null) {
                 for (ActivityInfo info : packageInfo.receivers) {
                     if (!sProcessList.contains(info.processName)) {


### PR DESCRIPTION
这里获取的PackageInfo没有包含任何services中的信息，所以下面对packageInfo.services != null的判断永远不成立，直接导致自定义的services进程被认为是插件进程。在宿主与该services多次通信后，会抛出TransactionTooLargeException。