### PR TITLE
修复7.0以上的手机插件输入框无法输入文字的bug

### DIFF
--- a/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/hook/handle/IInputMethodManagerHookHandle.java
+++ b/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/hook/handle/IInputMethodManagerHookHandle.java
@@ -44,6 +44,7 @@ public class IInputMethodManagerHookHandle extends BaseHookHandle {
     protected void init() {
         sHookedMethodHandlers.put("startInput", new startInput(mHostContext));
         sHookedMethodHandlers.put("windowGainedFocus", new windowGainedFocus(mHostContext));
+        sHookedMethodHandlers.put("startInputOrWindowGainedFocus", new startInputOrWindowGainedFocus(mHostContext));
     }
 
     private class IInputMethodManagerHookedMethodHandler extends HookedMethodHandler {
@@ -75,6 +76,12 @@ public class IInputMethodManagerHookHandle extends BaseHookHandle {
 
     private class windowGainedFocus extends IInputMethodManagerHookedMethodHandler {
         public windowGainedFocus(Context hostContext) {
+            super(hostContext);
+        }
+    }
+
+    private class startInputOrWindowGainedFocus extends IInputMethodManagerHookedMethodHandler {
+        public startInputOrWindowGainedFocus(Context hostContext) {
             super(hostContext);
         }
     }


### PR DESCRIPTION
通过源码分析是因为7.0的手机在startInputOrWindowGainedFocus方法中检查uid的时候没有hook到, 还没到startInput这一步.