### PR TITLE
①未兼容AndroidStudio3.0？ ②插件apk中无法使用极光推送？

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,6 @@ Droid Plugin
 
 [中文文档](readme_cn.md "中文文档")
 
-We just transfer the project to a new address for more no-official contributors
-The new address: [DroidPlugin](https://github.com/DroidPluginTeam/DroidPlugin "DroidPlugin")
-
 DroidPlugin is a new **Plugin Framework** developed and maintained by the Android app-store team at Qihoo 360 (NYSE:QIHU).
 It enables the host app run any third-party apk without installation, modification and repackage, which benefit a lot for collaborative development on Android.
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -4,9 +4,6 @@ Droid Plugin
 DroidPlugin 是***360手机助手***在Android系统上实现了一种新的***插件机制***:它可以在无需安装、修改的情况下运行APK文件,此机制对改进大型APP的架构，实现多团队协作开发具有一定的好处。
 -------
 
-为了让跟多的人参与到此项目，我们把项目迁移到一个新的组织DroidPlugin。
-项目新地址:[DroidPlugin](https://github.com/DroidPluginTeam/DroidPlugin "DroidPlugin")
-
 ##定义：
 
    


### PR DESCRIPTION
使用Android Studio3.0时，无法安装或加载插件，控制台返回：Package manager has died